### PR TITLE
スマホから直接BEのサーバーリストに追加

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -21,6 +21,7 @@ body {
   width: 90%;
   max-width: 22em;
   margin: 0.5em;
+  image-rendering: pixelated;
 }
 
 #copy {
@@ -135,6 +136,14 @@ body {
 .btn-flat:hover {
   color: white;
 }
+.b-Join {
+  color: #009c9e;
+  border: solid 4px #009c9e;
+}
+
+.b-Join:hover {
+  background: #009c9e;
+}
 
 .b-Dis {
   color: #5865f2;
@@ -200,4 +209,7 @@ body {
 /*PC*/
 
 @media (min-width: 639px) {
+  .b-join {
+    display: none;
+  }
 }

--- a/index.html
+++ b/index.html
@@ -39,6 +39,8 @@
     <div class="frame">
       <span class="ado">IP - Lovmc.ml</span>
       <span class="ado">ポート - 初期設定のまま</span>
+      <a href="minecraft://?addExternalServer=Lovmc.ml|lovmc.ml:19132" target="_blank" rel="noopener noreferrer"
+        class="btn-flat b-Join size"><span>いますぐ参加（BE）</span></a>
       <a href="https://novablog.work/be-join-any-server/" class="adoc">
         <span>Switch等から接続する場合 <i class="fas fa-external-link-alt"></i></span>
       </a>


### PR DESCRIPTION
スマホの時だけ直接Minecraftが起動してサーバーリストに追加されるボタンを出すのと
ロゴをカクカクにした